### PR TITLE
.csproj 内の Windows.winmd の HintPath 指定を修正

### DIFF
--- a/Source/Monitorian.Supplement/Monitorian.Supplement.csproj
+++ b/Source/Monitorian.Supplement/Monitorian.Supplement.csproj
@@ -49,7 +49,7 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5\System.Runtime.WindowsRuntime.dll</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETCore\v4.5\System.Runtime.WindowsRuntime.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -58,7 +58,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Windows">
-      <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.17134.0\Windows.winmd</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\$(TargetPlatformVersion)\Windows.winmd</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/StartupBridge/StartupBridge.csproj
+++ b/Source/StartupBridge/StartupBridge.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>StartupBridge</RootNamespace>
     <AssemblyName>StartupBridge</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
-    <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.17134.0</TargetPlatformVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -56,7 +56,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Windows">
-      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\Windows.winmd</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\$(TargetPlatformVersion)\Windows.winmd</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
こんにちは。Monitorian を便利に使わせて頂いています。
輝度値がうまく取得できないモニタがあった為、修正をしようとしていたところ、C# プロジェクトファイルの指定で Windows.winmd のパスに失敗しているところがありましたので、先だって修正してみました。
# 変更内容
* 現在の Windows SDK では、ビルド番号が付与したフォルダの下にあるようでしたので、\<TargetPlatformVersion> 指定から \<HintPath> を生成するようにしました。
* StartupBridge の \<TargetPlatformVersion> を、Monitorian.Supplement と同じく 10.0.17134.0 にしました。