### PR TITLE
Hot Key で輝度値を増減

### DIFF
--- a/Source/Monitorian/Helper/HotKeyHelper.cs
+++ b/Source/Monitorian/Helper/HotKeyHelper.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Monitorian.Helper
+{
+	internal static class HotKeyHelper
+	{
+		#region Win32
+
+		[DllImport("User32.dll", SetLastError = true)]
+		internal static extern bool RegisterHotKey(
+			IntPtr hWnd,
+			int id,
+			KeyModifiers fsModifiers,
+			System.Windows.Forms.Keys vk);
+
+		[Flags]
+		internal enum KeyModifiers : uint
+		{
+			MOD_ALT = 0x0001,
+			MOD_CONTROL = 0x0002,
+			MOD_SHIFT = 0x0004,
+			MOD_WIN = 0x0008,
+			MOD_NOREPEAT = 0x4000,
+		}
+
+		[DllImport("User32.dll", SetLastError = true)]
+		internal static extern bool UnregisterHotKey(
+			IntPtr hWnd,
+			int id);
+
+		internal const int WM_HOTKEY = 0x0312;
+		internal const int IDHOT_SNAPDESKTOP = -2;
+		internal const int IDHOT_SNAPWINDOW = -1;
+
+		#endregion
+	}
+
+	internal class HotKeyTuple
+	{
+		public int Id { get; set; }
+		public System.Windows.Forms.Keys VirtualKey { get; set; }
+		public HotKeyHelper.KeyModifiers KeyModifiers { get; set; }
+	}
+
+	internal class HotKeyEventArgs : EventArgs
+	{
+		public HotKeyEventArgs(HotKeyTuple args)
+		{
+			_args = args;
+		}
+
+		private readonly HotKeyTuple _args;
+
+		public int Id { get => _args.Id; }
+		public System.Windows.Forms.Keys VirtualKey { get => _args.VirtualKey; }
+		public HotKeyHelper.KeyModifiers KeyModifiers { get => _args.KeyModifiers; }
+	}
+
+	internal delegate void HotKeyEventHandler(object sender, HotKeyEventArgs e);
+}

--- a/Source/Monitorian/HotKeyListener.cs
+++ b/Source/Monitorian/HotKeyListener.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Windows.Forms;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using Monitorian.Models.Monitor;
+using Monitorian.Helper;
+
+namespace Monitorian
+{
+	class HotKeyListener : IDisposable
+	{
+		public enum HotKeyId : int
+		{
+			IncrementBrightness,
+			DecrementBrightness
+		}
+
+		private readonly HotKeyForm _listenerForm;
+
+		/// <summary>
+		/// Occurs when a hot key registerd by the RegisterHotKey function is pressed.
+		/// </summary>
+		public event HotKeyEventHandler HotKeyDown;
+
+		public HotKeyListener()
+		{
+			var requests = new List<HotKeyTuple>();
+			requests.Add(new HotKeyTuple
+			{
+				Id = (int)HotKeyId.IncrementBrightness,
+				KeyModifiers = HotKeyHelper.KeyModifiers.MOD_WIN,
+				VirtualKey = Keys.F9
+			});
+			requests.Add(new HotKeyTuple
+			{
+				Id = (int)HotKeyId.DecrementBrightness,
+				KeyModifiers = HotKeyHelper.KeyModifiers.MOD_WIN,
+				VirtualKey = Keys.F8
+			});
+
+			_listenerForm = new HotKeyForm(requests, this);
+		}
+
+		#region IDisposable
+
+		private bool _isDisposed = false;
+
+		/// <summary>
+		/// Public implementation of Dispose pattern
+		/// </summary>
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		/// <summary>
+		/// Protected implementation of Dispose pattern
+		/// </summary>
+		protected virtual void Dispose(bool disposing)
+		{
+			if (_isDisposed)
+				return;
+
+			if (disposing)
+			{
+				_listenerForm?.Dispose();
+			}
+
+			_isDisposed = true;
+		}
+
+		#endregion
+
+		private class HotKeyForm : Form
+		{
+			private List<HotKeyTuple> _hotKeys;
+			private HotKeyListener _ownerListener;
+
+			public HotKeyForm(List<HotKeyTuple> hotKeys, HotKeyListener ownerListener)
+			{
+				_hotKeys = hotKeys;
+				_ownerListener = ownerListener;
+
+				foreach (var hotKey in hotKeys)
+				{
+					var result = HotKeyHelper.RegisterHotKey(this.Handle, hotKey.Id, hotKey.KeyModifiers, hotKey.VirtualKey);
+					if (!result)
+					{
+						Debug.WriteLine($"Failed to register the hot key. {Error.CreateMessage()}");
+					}
+				}
+			}
+
+			protected override void WndProc(ref Message m)
+			{
+				switch (m.Msg)
+				{
+					case HotKeyHelper.WM_HOTKEY:
+						var hotkeyTuple = new HotKeyTuple
+						{
+							Id = (int)m.WParam,
+							VirtualKey = (Keys)Enum.ToObject(typeof(Keys), unchecked((short)(uint)m.WParam >> 16)),
+							KeyModifiers = (HotKeyHelper.KeyModifiers)Enum.ToObject(typeof(HotKeyHelper.KeyModifiers), unchecked((short)m.WParam))
+						};
+						_ownerListener.HotKeyDown?.Invoke(this, new HotKeyEventArgs(hotkeyTuple));
+						break;
+				}
+
+				base.WndProc(ref m);
+			}
+
+			protected override void Dispose(bool disposing)
+			{
+				foreach (var hotKey in _hotKeys)
+				{
+					var result = HotKeyHelper.UnregisterHotKey(this.Handle, hotKey.Id);
+					if (!result)
+					{
+						Debug.WriteLine($"Failed to unregister the hot key. {Error.CreateMessage()}");
+					}
+				}
+			}
+		}
+	}
+}

--- a/Source/Monitorian/MainController.cs
+++ b/Source/Monitorian/MainController.cs
@@ -17,6 +17,7 @@ using Monitorian.Models.Monitor;
 using Monitorian.Models.Watcher;
 using Monitorian.ViewModels;
 using Monitorian.Views;
+using Monitorian.Helper;
 using ScreenFrame;
 using StartupAgency;
 
@@ -38,6 +39,8 @@ namespace Monitorian
 		private readonly PowerWatcher _powerWatcher;
 		private readonly BrightnessWatcher _brightnessWatcher;
 
+		private readonly HotKeyListener _hotKeyListener;
+
 		public MainController(StartupAgent agent)
 		{
 			Settings = new Settings();
@@ -53,6 +56,9 @@ namespace Monitorian
 			_settingsWatcher = new SettingsWatcher();
 			_powerWatcher = new PowerWatcher();
 			_brightnessWatcher = new BrightnessWatcher();
+
+			_hotKeyListener = new HotKeyListener();
+			_hotKeyListener.HotKeyDown += OnHotKeyPressed;
 		}
 
 		internal async Task InitiateAsync()
@@ -85,6 +91,8 @@ namespace Monitorian
 			_settingsWatcher.Dispose();
 			_powerWatcher.Dispose();
 			_brightnessWatcher.Dispose();
+
+			_hotKeyListener.Dispose();
 		}
 
 		private async void OnMainWindowShowRequestedBySelf(object sender, EventArgs e)
@@ -129,6 +137,23 @@ namespace Monitorian
 		{
 			if (e.PropertyName == nameof(Settings.EnablesUnison))
 				OnSettingsEnablesUnisonChanged();
+		}
+
+		private void OnHotKeyPressed(object sender, HotKeyEventArgs e)
+		{
+			foreach (var monitor in Monitors)
+			{
+				switch (e.Id)
+				{
+					case (int)HotKeyListener.HotKeyId.IncrementBrightness:
+						monitor.IncrementBrightnessPercentage(1);
+						break;
+
+					case (int)HotKeyListener.HotKeyId.DecrementBrightness:
+						monitor.IncrementBrightnessPercentage(-1);
+						break;
+				}
+			}
 		}
 
 		#region Monitors

--- a/Source/Monitorian/Monitorian.csproj
+++ b/Source/Monitorian/Monitorian.csproj
@@ -81,10 +81,12 @@
     <Compile Include="Common\ObservableDictionary.cs" />
     <Compile Include="Common\ObservableKeyedList.cs" />
     <Compile Include="Helper\ExceptionExtension.cs" />
+    <Compile Include="Helper\HotKeyHelper.cs" />
     <Compile Include="Helper\OsVersion.cs" />
     <Compile Include="Helper\ArraySearch.cs" />
     <Compile Include="Helper\StringExtension.cs" />
     <Compile Include="Helper\Throttle.cs" />
+    <Compile Include="HotKeyListener.cs" />
     <Compile Include="MainController.cs" />
     <Compile Include="Models\ConsoleService.cs" />
     <Compile Include="Models\DocumentService.cs" />

--- a/Source/Monitorian/ViewModels/MonitorViewModel.cs
+++ b/Source/Monitorian/ViewModels/MonitorViewModel.cs
@@ -114,6 +114,22 @@ namespace Monitorian.ViewModels
 			SetBrightness(brightness);
 		}
 
+		public void IncrementBrightnessPercentage(int percentagePoint)
+		{
+			var newBrightnessPercentage = Brightness + percentagePoint;
+			if (newBrightnessPercentage == Brightness)
+			{
+				// No brightness changed
+				return;
+			}
+			if (newBrightnessPercentage > 100)
+				newBrightnessPercentage = 100;
+			if (newBrightnessPercentage < 0)
+				newBrightnessPercentage = 0;
+
+			SetBrightness(newBrightnessPercentage);
+		}
+
 		private void SetBrightness(int brightness)
 		{
 			if (_monitor.SetBrightness(brightness))


### PR DESCRIPTION
Windows ロゴ キー + F8 で輝度値を 1 減算し、Windows ロゴ キー + F9 で、輝度値を 1 加算するようにしてみました。外部モニターなので、輝度値の変更がキーボードリピートより遅く、引っかかるような動作になりますが、私としては、便利になりました。
Issues を見ると、ショートカットキーのサポートの予定は無いように見えました。Monitorian の方針として、キーボードによる輝度値の操作機能を、今後も入れないとのことでしたら、reject して頂いて構いません。