### PR TITLE
Main Window is now above Notification Overflow Area

### DIFF
--- a/Source/Monitorian.Core/AppControllerCore.cs
+++ b/Source/Monitorian.Core/AppControllerCore.cs
@@ -124,8 +124,12 @@ namespace Monitorian.Core
 			if ((window.Visibility == Visibility.Visible) && window.IsForeground)
 				return;
 
+			// Only Window.Show() works when Topmost in MainWindow.xaml is set to True.
+			window.Show();
+			/*
 			window.ShowForeground();
 			window.Activate();
+			*/
 		}
 
 		protected virtual void ShowMenuWindow(Point pivot)

--- a/Source/Monitorian.Core/Views/MainWindow.xaml
+++ b/Source/Monitorian.Core/Views/MainWindow.xaml
@@ -10,7 +10,7 @@
 		xmlns:properties="clr-namespace:Monitorian.Core.Properties"
 		Width="360" Height="200"
 		ResizeMode="NoResize" SizeToContent="WidthAndHeight"
-		ShowInTaskbar="False"
+		ShowInTaskbar="False" Topmost="True"
 		AllowsTransparency="True" WindowStyle="None"
 		Background="{StaticResource App.Background.Plain}">
 	<Window.Resources>


### PR DESCRIPTION
#53

This makes it so the Main Window is not obstructed by notification overflow area if the icon is placed there by the user.

Before:
<img src="https://user-images.githubusercontent.com/22629067/65156935-e8f78680-d9fd-11e9-869a-f944ab93d460.png" height="150">

After:
<img src="https://user-images.githubusercontent.com/22629067/65392150-7d842080-dd3f-11e9-8834-7c193658a3a2.png" height="150">
