### PR TITLE
docs: Remove additional symbols

### DIFF
--- a/Source/Monitorian.Core/Properties/Resources.zh-Hans.resx
+++ b/Source/Monitorian.Core/Properties/Resources.zh-Hans.resx
@@ -147,8 +147,8 @@
   <data name="OrderArrangement" xml:space="preserve">
     <value>按显示器排布进行排序</value>
   </data>
-  <data name="DeferChange" xml:space="preserve">^M
-    <value>延迟到关闭时生效</value>^M
+  <data name="DeferChange" xml:space="preserve">
+    <value>延迟到关闭时生效</value>
   </data>
   <data name="Probe" xml:space="preserve">
     <value>检测显示器</value>

--- a/Source/Monitorian.Core/Properties/Resources.zh-Hant.resx
+++ b/Source/Monitorian.Core/Properties/Resources.zh-Hant.resx
@@ -156,6 +156,9 @@
   <data name="OrderArrangement" xml:space="preserve">
     <value>按顯示器排列呈現</value>
   </data>
+  <data name="DeferChange" xml:space="preserve">
+    <value>延遲到關閉時生效</value>
+  </data>
   <data name="Probe" xml:space="preserve">
     <value>檢測顯示器</value>
   </data>


### PR DESCRIPTION
Useless symbols inadvertently introduced in the last commit #274 