### PR TITLE
 Adds the Chocolatey package as a way to install Monitorian

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Additional languages:
    winget install Monitorian
    ```
 
+ * Chocolatey (a.k.a. [Chocolatey Package Manager](https://community.chocolatey.org/packages/monitorian), App Installer):
+   ```
+   choco install monitorian
+   ```
+
  * Other:<br>
 :floppy_disk: [Installer](https://github.com/emoacht/Monitorian/releases/download/3.13.0-Installer/MonitorianInstaller3130.zip)
 


### PR DESCRIPTION
Hi Monitorian devs,

I have created this Pull Request because I have resolved this [request for a Chocolatey package](https://github.com/chocolatey-community/chocolatey-package-requests/issues/1061) and now, we can install **monitorian** using [Chocolatey](https://community.chocolatey.org/packages/monitorian).

For now, only the latest version (`3.13.0`) is available on Chocolatey. When new versions will be released, they will, then, be added to the Chocolatey package for users to enjoy. :slightly_smiling_face: 

