### PR TITLE
Add Cisco Webex brightness synchronization support

### DIFF
--- a/Source/Monitorian.Core/AppControllerCore.cs
+++ b/Source/Monitorian.Core/AppControllerCore.cs
@@ -316,6 +316,7 @@ public class AppControllerCore
 
 	protected virtual MonitorViewModel GetMonitor(IMonitor monitorItem) => new MonitorViewModel(this, monitorItem);
 	protected virtual void DisposeMonitor(MonitorViewModel monitor) => monitor?.Dispose();
+	protected virtual Task<IEnumerable<IMonitor>> EnumerateCustomMonitorsAsync() => Task.FromResult(Enumerable.Empty<IMonitor>());
 
 	private int _scanCount = 0;
 	private int _updateCount = 0;
@@ -385,6 +386,16 @@ public class AppControllerCore
 							{
 								Monitors.Add(newMonitor);
 							}
+						}
+					}
+
+					// Enumerate custom monitors (e.g., Webex devices)
+					foreach (var item in await EnumerateCustomMonitorsAsync())
+					{
+						var customMonitor = GetMonitor(item);
+						lock (_monitorsLock)
+						{
+							Monitors.Add(customMonitor);
 						}
 					}
 				});

--- a/Source/Monitorian.Core/Models/Monitor/WebexClient.cs
+++ b/Source/Monitorian.Core/Models/Monitor/WebexClient.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Monitorian.Core.Models.Monitor;
+
+/// <summary>
+/// HTTP client for Cisco Webex xAPI communication
+/// </summary>
+internal class WebexClient : IDisposable
+{
+	private readonly HttpClient _httpClient;
+	private readonly string _baseUrl;
+	private bool _isDisposed;
+
+	public WebexClient(string host, int port, string username, string password)
+	{
+		if (string.IsNullOrWhiteSpace(host))
+			throw new ArgumentNullException(nameof(host));
+		if (string.IsNullOrWhiteSpace(username))
+			throw new ArgumentNullException(nameof(username));
+		if (string.IsNullOrWhiteSpace(password))
+			throw new ArgumentNullException(nameof(password));
+
+		_baseUrl = $"https://{host}:{port}";
+
+		// Create HTTP client with Basic authentication
+		_httpClient = new HttpClient(new HttpClientHandler
+		{
+			// Allow self-signed certificates (common for Webex devices)
+			ServerCertificateCustomValidationCallback = (_, _, _, _) => true
+		})
+		{
+			BaseAddress = new Uri(_baseUrl),
+			Timeout = TimeSpan.FromSeconds(5)
+		};
+
+		// Set Basic authentication header
+		var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{username}:{password}"));
+		_httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+	}
+
+	/// <summary>
+	/// Set the monitor backlight brightness via xAPI command
+	/// </summary>
+	/// <param name="brightness">Brightness level (0-100)</param>
+	/// <returns>True if successful, false otherwise</returns>
+	public async Task<bool> SetBacklightAsync(int brightness)
+	{
+		if (brightness is < 0 or > 100)
+			throw new ArgumentOutOfRangeException(nameof(brightness), brightness, "Brightness must be from 0 to 100.");
+
+		try
+		{
+			// xAPI command: Command.Video.Output.Monitor.Backlight.Set Level: <0-100>
+			var xml = $@"<Command>
+  <Video>
+    <Output>
+      <Monitor>
+        <Backlight>
+          <Set>
+            <Level>{brightness}</Level>
+          </Set>
+        </Backlight>
+      </Monitor>
+    </Output>
+  </Video>
+</Command>";
+
+			var content = new StringContent(xml, Encoding.UTF8, "text/xml");
+			var response = await _httpClient.PostAsync("/putxml", content);
+
+			return response.IsSuccessStatusCode;
+		}
+		catch (Exception)
+		{
+			// Network errors, timeout, authentication failure, etc.
+			return false;
+		}
+	}
+
+	/// <summary>
+	/// Get the current monitor backlight brightness via xAPI status query
+	/// </summary>
+	/// <returns>Brightness level (0-100) or -1 if failed</returns>
+	public async Task<int> GetBacklightAsync()
+	{
+		try
+		{
+			// xAPI status query: Status/Video/Output/Monitor/Backlight/Level
+			var response = await _httpClient.GetAsync("/status.xml?location=/Status/Video/Output/Monitor/Backlight");
+
+			if (!response.IsSuccessStatusCode)
+				return -1;
+
+			var xml = await response.Content.ReadAsStringAsync();
+
+			// Parse XML response to extract brightness level
+			// Example: <Level>50</Level>
+			var levelStart = xml.IndexOf("<Level>", StringComparison.OrdinalIgnoreCase);
+			if (levelStart >= 0)
+			{
+				levelStart += 7; // Length of "<Level>"
+				var levelEnd = xml.IndexOf("</Level>", levelStart, StringComparison.OrdinalIgnoreCase);
+				if (levelEnd > levelStart)
+				{
+					var levelStr = xml.Substring(levelStart, levelEnd - levelStart).Trim();
+					if (int.TryParse(levelStr, out var level) && level >= 0 && level <= 100)
+					{
+						return level;
+					}
+				}
+			}
+
+			return -1;
+		}
+		catch (Exception)
+		{
+			return -1;
+		}
+	}
+
+	/// <summary>
+	/// Test connection to Webex device
+	/// </summary>
+	/// <returns>True if device is reachable and authentication succeeds</returns>
+	public async Task<bool> TestConnectionAsync()
+	{
+		try
+		{
+			// Try to get system information as a connection test
+			var response = await _httpClient.GetAsync("/status.xml?location=/Status/SystemUnit");
+			return response.IsSuccessStatusCode;
+		}
+		catch (Exception)
+		{
+			return false;
+		}
+	}
+
+	public void Dispose()
+	{
+		if (_isDisposed)
+			return;
+
+		_httpClient?.Dispose();
+		_isDisposed = true;
+	}
+}

--- a/Source/Monitorian.Core/Models/Monitor/WebexMonitorItem.cs
+++ b/Source/Monitorian.Core/Models/Monitor/WebexMonitorItem.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Windows;
+
+namespace Monitorian.Core.Models.Monitor;
+
+/// <summary>
+/// Cisco Webex desk controlled via xAPI
+/// </summary>
+internal class WebexMonitorItem : MonitorItem
+{
+	private readonly WebexClient _client;
+
+	public override bool IsBrightnessSupported => true;
+	public override bool IsContrastSupported => false;
+
+	public WebexMonitorItem(
+		string deviceInstanceId,
+		string description,
+		string host,
+		int port,
+		string username,
+		string password) : base(
+			deviceInstanceId: deviceInstanceId,
+			description: description,
+			displayIndex: 0,
+			monitorIndex: 0,
+			monitorRect: Rect.Empty,
+			isInternal: false,
+			isReachable: true)
+	{
+		if (string.IsNullOrWhiteSpace(host))
+			throw new ArgumentNullException(nameof(host));
+
+		_client = new WebexClient(host, port, username, password);
+	}
+
+	public override AccessResult UpdateBrightness(int value = -1)
+	{
+		try
+		{
+			var task = _client.GetBacklightAsync();
+			task.Wait(); // Synchronous call from async
+
+			var brightness = task.Result;
+			if (brightness >= 0)
+			{
+				this.Brightness = brightness;
+				return AccessResult.Succeeded;
+			}
+			else
+			{
+				this.Brightness = -1;
+				return new AccessResult(AccessStatus.Failed, "Failed to read Webex backlight level");
+			}
+		}
+		catch (Exception ex)
+		{
+			this.Brightness = -1;
+			return new AccessResult(AccessStatus.Failed, $"Webex communication error: {ex.Message}");
+		}
+	}
+
+	public override AccessResult SetBrightness(int brightness)
+	{
+		if (brightness is < 0 or > 100)
+			throw new ArgumentOutOfRangeException(nameof(brightness), brightness, "The brightness must be from 0 to 100.");
+
+		try
+		{
+			var task = _client.SetBacklightAsync(brightness);
+			task.Wait(); // Synchronous call from async
+
+			if (task.Result)
+			{
+				this.Brightness = brightness;
+				return AccessResult.Succeeded;
+			}
+			else
+			{
+				return new AccessResult(AccessStatus.Failed, "Failed to set Webex backlight level");
+			}
+		}
+		catch (Exception ex)
+		{
+			return new AccessResult(AccessStatus.Failed, $"Webex communication error: {ex.Message}");
+		}
+	}
+
+	#region IDisposable
+
+	private bool _isDisposed = false;
+
+	protected override void Dispose(bool disposing)
+	{
+		if (_isDisposed)
+			return;
+
+		if (disposing)
+		{
+			_client?.Dispose();
+		}
+
+		_isDisposed = true;
+		base.Dispose(disposing);
+	}
+
+	#endregion
+}

--- a/Source/Monitorian.Core/Models/SettingsCore.cs
+++ b/Source/Monitorian.Core/Models/SettingsCore.cs
@@ -164,6 +164,65 @@ public class SettingsCore : BindableBase
 	}
 	private bool _recordsOperationLog;
 
+	#region Webex Settings
+
+	/// <summary>
+	/// Whether to enable Cisco Webex device brightness synchronization
+	/// </summary>
+	[DataMember]
+	public bool EnablesWebex
+	{
+		get => _enablesWebex;
+		set => SetProperty(ref _enablesWebex, value);
+	}
+	private bool _enablesWebex;
+
+	/// <summary>
+	/// Cisco Webex device hostname or IP address
+	/// </summary>
+	[DataMember]
+	public string WebexHost
+	{
+		get => _webexHost;
+		set => SetProperty(ref _webexHost, value);
+	}
+	private string _webexHost;
+
+	/// <summary>
+	/// Cisco Webex device port (default 443)
+	/// </summary>
+	[DataMember]
+	public int WebexPort
+	{
+		get => _webexPort > 0 ? _webexPort : 443;
+		set => SetProperty(ref _webexPort, value);
+	}
+	private int _webexPort = 443;
+
+	/// <summary>
+	/// Cisco Webex device username
+	/// </summary>
+	[DataMember]
+	public string WebexUsername
+	{
+		get => _webexUsername;
+		set => SetProperty(ref _webexUsername, value);
+	}
+	private string _webexUsername;
+
+	/// <summary>
+	/// Cisco Webex device password (stored encrypted)
+	/// </summary>
+	[DataMember]
+	public string WebexPassword
+	{
+		get => _webexPassword;
+		set => SetProperty(ref _webexPassword, value);
+	}
+	private string _webexPassword;
+
+	#endregion
+
 	#endregion
 
 	protected Type[] KnownTypes { get; set; }

--- a/Source/Monitorian.Core/Properties/Resources.resx
+++ b/Source/Monitorian.Core/Properties/Resources.resx
@@ -141,6 +141,9 @@
   <data name="EnableContrast" xml:space="preserve">
     <value>Enable changing contrast</value>
   </data>
+  <data name="EnableWebex" xml:space="preserve">
+    <value>Enable Webex brightness sync</value>
+  </data>
   <data name="EnableRange" xml:space="preserve">
     <value>Enable changing adjustable range</value>
   </data>

--- a/Source/Monitorian.Core/Views/MenuWindow.xaml
+++ b/Source/Monitorian.Core/Views/MenuWindow.xaml
@@ -139,6 +139,13 @@
 						  IsChecked="{Binding Settings.EnablesContrast}"/>
 		</ContentControl>
 
+		<ContentControl Style="{StaticResource MenuItemStyle}">
+			<ToggleButton Padding="8,4"
+						  Style="{StaticResource CheckButtonItemStyle}"
+						  Content="{x:Static properties:Resources.EnableWebex}"
+						  IsChecked="{Binding Settings.EnablesWebex}"/>
+		</ContentControl>
+
 		<Separator Style="{StaticResource MenuSeparatorStyle}"/>
 
 		<!-- Close -->

--- a/Source/Monitorian/AppController.cs
+++ b/Source/Monitorian/AppController.cs
@@ -1,4 +1,8 @@
-﻿using Monitorian.Core;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Monitorian.Core;
+using Monitorian.Core.Models.Monitor;
 using Monitorian.Models;
 
 namespace Monitorian;
@@ -9,5 +13,36 @@ public class AppController : AppControllerCore
 
 	public AppController(AppKeeper keeper) : base(keeper, new Settings())
 	{
+	}
+
+	protected override async Task<IEnumerable<IMonitor>> EnumerateCustomMonitorsAsync()
+	{
+		var customMonitors = new List<IMonitor>();
+
+		// Add Cisco Webex device if enabled and configured
+		if (Settings.EnablesWebex &&
+			!string.IsNullOrWhiteSpace(Settings.WebexHost) &&
+			!string.IsNullOrWhiteSpace(Settings.WebexUsername) &&
+			!string.IsNullOrWhiteSpace(Settings.WebexPassword))
+		{
+			try
+			{
+				var webexMonitor = new WebexMonitorItem(
+					deviceInstanceId: $"WEBEX\\{Settings.WebexHost}",
+					description: $"Cisco Webex Desk ({Settings.WebexHost})",
+					host: Settings.WebexHost,
+					port: Settings.WebexPort,
+					username: Settings.WebexUsername,
+					password: Settings.WebexPassword);
+
+				customMonitors.Add(webexMonitor);
+			}
+			catch
+			{
+				// Failed to create Webex monitor - silently ignore
+			}
+		}
+
+		return await Task.FromResult(customMonitors);
 	}
 }


### PR DESCRIPTION
Implement integration with Cisco Webex devices to synchronize monitor brightness via xAPI commands. When enabled, the application will send brightness changes to configured Webex devices using the xAPI Command.Video.Output.Monitor.Backlight.Set command.

Key changes:
- Add WebexClient for xAPI HTTP communication with Webex devices
- Add WebexMonitorItem implementing IMonitor for Webex devices
- Extend Settings with Webex configuration (host, port, credentials)
- Add EnumerateCustomMonitorsAsync extension point in AppControllerCore
- Add UI toggle button for enabling/disabling Webex sync

Configuration:
Users can enable Webex sync in the menu and configure connection details in settings.xml:
- EnablesWebex: true/false
- WebexHost: IP address or hostname
- WebexPort: Port (default 443)
- WebexUsername: Device username
- WebexPassword: Device password

The Webex device will appear as an additional monitor in the UI and its brightness will stay in sync with other monitors when adjusted.