### PR TITLE
Add UI for input source switching (VCP code 0x60)

### DIFF
--- a/Source/Monitorian.Core/AppControllerCore.cs
+++ b/Source/Monitorian.Core/AppControllerCore.cs
@@ -265,6 +265,12 @@ public class AppControllerCore
 
 				break;
 
+			case nameof(Settings.EnablesInputSource) when !Settings.EnablesInputSource:
+				foreach (var m in Monitors)
+					m.IsInputSourceChanging = false;
+
+				break;
+
 			case nameof(Settings.RecordsOperationLog):
 				if (Settings.RecordsOperationLog)
 					await OperationRecorder.EnableAsync("Enabled");
@@ -538,7 +544,7 @@ public class AppControllerCore
 
 	#region Customization
 
-	protected internal virtual bool TryLoadCustomization(string deviceInstanceId, ref string name, ref bool isUnison, ref byte lowest, ref byte highest)
+	protected internal virtual bool TryLoadCustomization(string deviceInstanceId, ref string name, ref bool isUnison, ref byte lowest, ref byte highest, ref InputSourceItem[] inputSources)
 	{
 		if (Settings.MonitorCustomizations.TryGetValue(deviceInstanceId, out MonitorCustomizationItem m)
 			&& m.IsValid)
@@ -547,14 +553,15 @@ public class AppControllerCore
 			isUnison = m.IsUnison && Settings.EnablesUnison;
 			lowest = m.Lowest;
 			highest = m.Highest;
+			inputSources = m.InputSources;
 			return true;
 		}
 		return false;
 	}
 
-	protected internal virtual void SaveCustomization(string deviceInstanceId, string name, bool isUnison, byte lowest, byte highest)
+	protected internal virtual void SaveCustomization(string deviceInstanceId, string name, bool isUnison, byte lowest, byte highest, InputSourceItem[] inputSources)
 	{
-		MonitorCustomizationItem m = new(name, isUnison, lowest, highest);
+		MonitorCustomizationItem m = new(name, isUnison, lowest, highest, inputSources);
 		if (m.IsValid && !m.IsDefault)
 		{
 			Settings.MonitorCustomizations.Add(deviceInstanceId, m);

--- a/Source/Monitorian.Core/Models/SettingsCore.cs
+++ b/Source/Monitorian.Core/Models/SettingsCore.cs
@@ -132,6 +132,17 @@ public class SettingsCore : BindableBase
 	private bool _enablesContrast;
 
 	/// <summary>
+	/// Whether to enable input source switching
+	/// </summary>
+	[DataMember]
+	public bool EnablesInputSource
+	{
+		get => _enablesInputSource;
+		set => SetProperty(ref _enablesInputSource, value);
+	}
+	private bool _enablesInputSource;
+
+	/// <summary>
 	/// Monitor customizations by user
 	/// </summary>
 	[DataMember]
@@ -244,12 +255,19 @@ public class MonitorCustomizationItem
 	[DataMember]
 	public byte Highest { get; private set; } = 100;
 
-	public MonitorCustomizationItem(string name, bool isUnison, byte lowest, byte highest)
+	/// <summary>
+	/// Configured input sources with their labels (VCP code 0x60 values)
+	/// </summary>
+	[DataMember]
+	public InputSourceItem[] InputSources { get; private set; }
+
+	public MonitorCustomizationItem(string name, bool isUnison, byte lowest, byte highest, InputSourceItem[] inputSources = null)
 	{
 		this.Name = name;
 		this.IsUnison = isUnison;
 		this.Lowest = lowest;
 		this.Highest = highest;
+		this.InputSources = inputSources;
 	}
 
 	internal bool IsValid
@@ -261,6 +279,72 @@ public class MonitorCustomizationItem
 	{
 		get => (Name is null)
 			&& (IsUnison == default)
-			&& (Lowest, Highest) is (0, 100);
+			&& (Lowest, Highest) is (0, 100)
+			&& (InputSources is null || InputSources.Length == 0);
+	}
+}
+
+/// <summary>
+/// Input source configuration item
+/// </summary>
+[DataContract]
+public class InputSourceItem
+{
+	/// <summary>
+	/// VCP code 0x60 value for this input source
+	/// </summary>
+	[DataMember]
+	public byte Value { get; set; }
+
+	/// <summary>
+	/// User-defined label for this input source
+	/// </summary>
+	[DataMember]
+	public string Label { get; set; }
+
+	/// <summary>
+	/// Whether this input is enabled for quick switching
+	/// </summary>
+	[DataMember]
+	public bool IsEnabled { get; set; }
+
+	public InputSourceItem() { }
+
+	public InputSourceItem(byte value, string label, bool isEnabled = true)
+	{
+		this.Value = value;
+		this.Label = label;
+		this.IsEnabled = isEnabled;
+	}
+
+	/// <summary>
+	/// Gets the default label for an input source VCP value
+	/// </summary>
+	public static string GetDefaultLabel(byte value)
+	{
+		return value switch
+		{
+			0x01 => "VGA 1",
+			0x02 => "VGA 2",
+			0x03 => "DVI 1",
+			0x04 => "DVI 2",
+			0x05 => "Composite 1",
+			0x06 => "Composite 2",
+			0x07 => "S-Video 1",
+			0x08 => "S-Video 2",
+			0x09 => "Tuner 1",
+			0x0A => "Tuner 2",
+			0x0B => "Tuner 3",
+			0x0C => "Component 1",
+			0x0D => "Component 2",
+			0x0E => "Component 3",
+			0x0F => "DisplayPort 1",
+			0x10 => "DisplayPort 2",
+			0x11 => "HDMI 1",
+			0x12 => "HDMI 2",
+			0x13 => "USB-C 1",
+			0x14 => "USB-C 2",
+			_ => $"Input {value:X2}"
+		};
 	}
 }

--- a/Source/Monitorian.Core/Monitorian.Core.csproj
+++ b/Source/Monitorian.Core/Monitorian.Core.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Views\Controls\FrameworkElementMargin.cs" />
     <Compile Include="Views\Controls\FrameworkElementSize.cs" />
     <Compile Include="Views\Controls\IconButton.cs" />
+    <Compile Include="Views\Controls\InputSourceButton.cs" />
     <Compile Include="Views\Controls\MultiToggleButton.cs" />
     <Compile Include="Views\Controls\PulseLabel.cs" />
     <Compile Include="Views\Controls\SwitchTextBox.cs" />
@@ -149,6 +150,9 @@
     <Compile Include="Views\Input\MouseAddition.cs" />
     <Compile Include="Views\DevSection.xaml.cs">
       <DependentUpon>DevSection.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\InputSourceConfigWindow.xaml.cs">
+      <DependentUpon>InputSourceConfigWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
@@ -279,6 +283,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\Generic.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\InputSourceConfigWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/Source/Monitorian.Core/Properties/Resources.Designer.cs
+++ b/Source/Monitorian.Core/Properties/Resources.Designer.cs
@@ -266,5 +266,23 @@ namespace Monitorian.Core.Properties {
                 return ResourceManager.GetString("UseLargeElements", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Switch input source.
+        /// </summary>
+        public static string SwitchInputSource {
+            get {
+                return ResourceManager.GetString("SwitchInputSource", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Enable switching input source.
+        /// </summary>
+        public static string EnableInputSource {
+            get {
+                return ResourceManager.GetString("EnableInputSource", resourceCulture);
+            }
+        }
     }
 }

--- a/Source/Monitorian.Core/Properties/Resources.resx
+++ b/Source/Monitorian.Core/Properties/Resources.resx
@@ -186,4 +186,10 @@
   <data name="UseLargeElements" xml:space="preserve">
     <value>Use large sliders</value>
   </data>
+  <data name="SwitchInputSource" xml:space="preserve">
+    <value>Switch input source</value>
+  </data>
+  <data name="EnableInputSource" xml:space="preserve">
+    <value>Enable switching input source</value>
+  </data>
 </root>

--- a/Source/Monitorian.Core/ViewModels/MonitorViewModel.cs
+++ b/Source/Monitorian.Core/ViewModels/MonitorViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 
@@ -54,8 +55,8 @@ public class MonitorViewModel : ViewModelBase
 
 	#region Customization
 
-	private void LoadCustomization() => _controller.TryLoadCustomization(DeviceInstanceId, ref _name, ref _isUnison, ref _rangeLowest, ref _rangeHighest);
-	private void SaveCustomization() => _controller.SaveCustomization(DeviceInstanceId, _name, _isUnison, _rangeLowest, _rangeHighest);
+	private void LoadCustomization() => _controller.TryLoadCustomization(DeviceInstanceId, ref _name, ref _isUnison, ref _rangeLowest, ref _rangeHighest, ref _inputSources);
+	private void SaveCustomization() => _controller.SaveCustomization(DeviceInstanceId, _name, _isUnison, _rangeLowest, _rangeHighest, _inputSources);
 
 	public string Name
 	{
@@ -379,6 +380,143 @@ public class MonitorViewModel : ViewModelBase
 	}
 
 	public DateTimeOffset ContrastUpdatedTime { get; private set; }
+
+	#endregion
+
+	#region Input Source
+
+	private const byte InputSourceVcpCode = 0x60;
+
+	/// <summary>
+	/// Whether input source switching is supported
+	/// </summary>
+	public bool IsInputSourceSupported
+	{
+		get
+		{
+			var (success, data) = GetValue(InputSourceVcpCode);
+			return success == true && data?.Values?.Count > 0;
+		}
+	}
+
+	/// <summary>
+	/// Whether the input source popup is showing
+	/// </summary>
+	public bool IsInputSourceChanging
+	{
+		get => _isInputSourceChanging;
+		set
+		{
+			if (SetProperty(ref _isInputSourceChanging, value) && value)
+				UpdateInputSource();
+		}
+	}
+	private bool _isInputSourceChanging = false;
+
+	/// <summary>
+	/// Configured input sources
+	/// </summary>
+	public InputSourceItem[] InputSources
+	{
+		get => _inputSources;
+		set
+		{
+			if (SetProperty(ref _inputSources, value))
+				SaveCustomization();
+		}
+	}
+	private InputSourceItem[] _inputSources;
+
+	/// <summary>
+	/// Current input source value
+	/// </summary>
+	public byte CurrentInputSource
+	{
+		get => _currentInputSource;
+		private set => SetProperty(ref _currentInputSource, value);
+	}
+	private byte _currentInputSource;
+
+	/// <summary>
+	/// Available input source values from monitor capabilities
+	/// </summary>
+	public byte[] AvailableInputSources
+	{
+		get => _availableInputSources;
+		private set => SetProperty(ref _availableInputSources, value);
+	}
+	private byte[] _availableInputSources;
+
+	/// <summary>
+	/// Updates the current input source from the monitor
+	/// </summary>
+	public bool UpdateInputSource()
+	{
+		var (success, data) = GetValue(InputSourceVcpCode);
+
+		if (success == true && data != null)
+		{
+			CurrentInputSource = data.Value;
+			if (data.Values != null)
+			{
+				AvailableInputSources = data.Values.ToArray();
+			}
+			OnPropertyChanged(nameof(CurrentInputSourceLabel));
+			return true;
+		}
+		return false;
+	}
+
+	/// <summary>
+	/// Sets the input source on the monitor
+	/// </summary>
+	public bool SetInputSource(byte value)
+	{
+		var (success, data) = SetValue(InputSourceVcpCode, value);
+
+		if (success == true)
+		{
+			CurrentInputSource = value;
+			OnPropertyChanged(nameof(CurrentInputSourceLabel));
+			return true;
+		}
+		return false;
+	}
+
+	/// <summary>
+	/// Gets the label for the current input source
+	/// </summary>
+	public string CurrentInputSourceLabel
+	{
+		get
+		{
+			var configured = _inputSources?.FirstOrDefault(x => x.Value == CurrentInputSource);
+			return configured?.Label ?? InputSourceItem.GetDefaultLabel(CurrentInputSource);
+		}
+	}
+
+	/// <summary>
+	/// Gets the label for a given input source value
+	/// </summary>
+	public string GetInputSourceLabel(byte value)
+	{
+		var configured = _inputSources?.FirstOrDefault(x => x.Value == value);
+		return configured?.Label ?? InputSourceItem.GetDefaultLabel(value);
+	}
+
+	/// <summary>
+	/// Gets the enabled input sources for quick switching
+	/// </summary>
+	public InputSourceItem[] GetEnabledInputSources()
+	{
+		if (_inputSources == null || _inputSources.Length == 0)
+		{
+			// Return default sources from available inputs
+			return AvailableInputSources?.Select(v => new InputSourceItem(v, InputSourceItem.GetDefaultLabel(v), true)).ToArray()
+				?? Array.Empty<InputSourceItem>();
+		}
+		return _inputSources.Where(x => x.IsEnabled).ToArray();
+	}
 
 	#endregion
 

--- a/Source/Monitorian.Core/Views/Controls/InputSourceButton.cs
+++ b/Source/Monitorian.Core/Views/Controls/InputSourceButton.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using System.Windows.Media;
+
+using Monitorian.Core.Models;
+using Monitorian.Core.ViewModels;
+using Monitorian.Core.Views;
+
+namespace Monitorian.Core.Views.Controls;
+
+/// <summary>
+/// A button that shows a popup for input source selection
+/// </summary>
+public class InputSourceButton : ToggleButton
+{
+	#region Icon
+
+	public Geometry StrokeIconData
+	{
+		get { return (Geometry)GetValue(StrokeIconDataProperty); }
+		set { SetValue(StrokeIconDataProperty, value); }
+	}
+	public static readonly DependencyProperty StrokeIconDataProperty =
+		DependencyProperty.Register(
+			"StrokeIconData",
+			typeof(Geometry),
+			typeof(InputSourceButton),
+			new PropertyMetadata(defaultValue: null));
+
+	public Geometry FillIconData
+	{
+		get { return (Geometry)GetValue(FillIconDataProperty); }
+		set { SetValue(FillIconDataProperty, value); }
+	}
+	public static readonly DependencyProperty FillIconDataProperty =
+		DependencyProperty.Register(
+			"FillIconData",
+			typeof(Geometry),
+			typeof(InputSourceButton),
+			new PropertyMetadata(defaultValue: null));
+
+	#endregion
+
+	#region Visibility
+
+	public bool IsLastVisibleButton
+	{
+		get { return (bool)GetValue(IsLastVisibleButtonProperty); }
+		set { SetValue(IsLastVisibleButtonProperty, value); }
+	}
+	public static readonly DependencyProperty IsLastVisibleButtonProperty =
+		DependencyProperty.Register(
+			"IsLastVisibleButton",
+			typeof(bool),
+			typeof(InputSourceButton),
+			new PropertyMetadata(false));
+
+	#endregion
+
+	private Popup _popup;
+	private ItemsControl _itemsControl;
+	private UIElement _parent;
+
+	public InputSourceButton()
+	{
+		this.Loaded += OnLoaded;
+		this.Unloaded += OnUnloaded;
+	}
+
+	private void OnLoaded(object sender, RoutedEventArgs e)
+	{
+		CreatePopup();
+	}
+
+	private void OnUnloaded(object sender, RoutedEventArgs e)
+	{
+		if (_popup != null)
+		{
+			_popup.Opened -= OnPopupOpened;
+			_popup.Closed -= OnPopupClosed;
+		}
+	}
+
+	private void CreatePopup()
+	{
+		if (_popup != null)
+			return;
+
+		_itemsControl = new ItemsControl
+		{
+			Background = (Brush)FindResource("App.Background.Plain"),
+			Foreground = (Brush)FindResource("App.Foreground"),
+			MinWidth = 100
+		};
+
+		_popup = new Popup
+		{
+			PlacementTarget = this,
+			Placement = PlacementMode.Bottom,
+			StaysOpen = false,
+			AllowsTransparency = true,
+			Child = new Border
+			{
+				Background = (Brush)FindResource("App.Background.Plain"),
+				BorderBrush = (Brush)FindResource("App.Foreground"),
+				BorderThickness = new Thickness(1),
+				Padding = new Thickness(4),
+				Child = _itemsControl
+			}
+		};
+
+		_popup.Opened += OnPopupOpened;
+		_popup.Closed += OnPopupClosed;
+	}
+
+	protected override void OnChecked(RoutedEventArgs e)
+	{
+		base.OnChecked(e);
+
+		if (_popup != null && DataContext is MonitorViewModel vm)
+		{
+			vm.UpdateInputSource();
+			PopulateInputSources(vm);
+			_popup.IsOpen = true;
+		}
+	}
+
+	protected override void OnUnchecked(RoutedEventArgs e)
+	{
+		base.OnUnchecked(e);
+
+		if (_popup != null)
+		{
+			_popup.IsOpen = false;
+		}
+	}
+
+	private void OnPopupOpened(object sender, EventArgs e)
+	{
+		// Keep checked state while popup is open
+	}
+
+	private void OnPopupClosed(object sender, EventArgs e)
+	{
+		IsChecked = false;
+	}
+
+	private void PopulateInputSources(MonitorViewModel vm)
+	{
+		_itemsControl.Items.Clear();
+
+		var enabledSources = vm.GetEnabledInputSources();
+
+		foreach (var source in enabledSources)
+		{
+			var isCurrentInput = source.Value == vm.CurrentInputSource;
+			var button = new Button
+			{
+				Content = source.Label,
+				Tag = source.Value,
+				Padding = new Thickness(8, 4, 8, 4),
+				Margin = new Thickness(0, 2, 0, 2),
+				HorizontalContentAlignment = HorizontalAlignment.Left,
+				Background = isCurrentInput
+					? new SolidColorBrush((Color)FindResource("App.Background.Accent.StaticColor"))
+					: Brushes.Transparent,
+				Foreground = (Brush)FindResource("App.Foreground"),
+				BorderThickness = new Thickness(0),
+				Cursor = Cursors.Hand
+			};
+
+			button.Click += (s, e) =>
+			{
+				if (s is Button btn && btn.Tag is byte value)
+				{
+					vm.SetInputSource(value);
+					_popup.IsOpen = false;
+				}
+			};
+
+			_itemsControl.Items.Add(button);
+		}
+
+		// Add configure option at the bottom
+		var separator = new Separator
+		{
+			Margin = new Thickness(0, 4, 0, 4)
+		};
+		_itemsControl.Items.Add(separator);
+
+		var configureButton = new Button
+		{
+			Content = "Configure...",
+			Padding = new Thickness(8, 4, 8, 4),
+			Margin = new Thickness(0, 2, 0, 2),
+			HorizontalContentAlignment = HorizontalAlignment.Left,
+			Background = Brushes.Transparent,
+			Foreground = (Brush)FindResource("App.Foreground"),
+			BorderThickness = new Thickness(0),
+			Cursor = Cursors.Hand,
+			FontStyle = FontStyles.Italic
+		};
+
+		configureButton.Click += (s, e) =>
+		{
+			_popup.IsOpen = false;
+			ShowConfigurationDialog(vm);
+		};
+
+		_itemsControl.Items.Add(configureButton);
+	}
+
+	private void ShowConfigurationDialog(MonitorViewModel vm)
+	{
+		var window = new InputSourceConfigWindow(vm)
+		{
+			Owner = Window.GetWindow(this)
+		};
+		window.ShowDialog();
+	}
+
+	protected override void OnMouseDown(MouseButtonEventArgs e)
+	{
+		base.OnMouseDown(e);
+
+		var args = new MouseButtonEventArgs(Mouse.PrimaryDevice, Environment.TickCount, e.ChangedButton) { RoutedEvent = Mouse.MouseDownEvent };
+		_parent ??= VisualTreeHelper.GetParent(this) as UIElement;
+		_parent?.RaiseEvent(args);
+	}
+}

--- a/Source/Monitorian.Core/Views/InputSourceConfigWindow.xaml
+++ b/Source/Monitorian.Core/Views/InputSourceConfigWindow.xaml
@@ -1,0 +1,91 @@
+<Window x:Class="Monitorian.Core.Views.InputSourceConfigWindow"
+		xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+		Title="Configure Input Sources"
+		Width="350" Height="400"
+		WindowStartupLocation="CenterOwner"
+		ResizeMode="NoResize"
+		ShowInTaskbar="False"
+		Background="{DynamicResource App.Background.Plain}">
+	<Window.Resources>
+		<Style x:Key="InputItemStyle" TargetType="{x:Type Border}">
+			<Setter Property="Background" Value="Transparent"/>
+			<Setter Property="BorderThickness" Value="0,0,0,1"/>
+			<Setter Property="BorderBrush" Value="{DynamicResource App.Foreground.Shadow}"/>
+			<Setter Property="Padding" Value="8,6"/>
+		</Style>
+	</Window.Resources>
+
+	<Grid Margin="12">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto"/>
+			<RowDefinition Height="*"/>
+			<RowDefinition Height="Auto"/>
+		</Grid.RowDefinitions>
+
+		<TextBlock Grid.Row="0"
+				   Text="Configure which input sources appear in the quick switch menu and their labels:"
+				   TextWrapping="Wrap"
+				   Margin="0,0,0,12"
+				   Foreground="{DynamicResource App.Foreground}"/>
+
+		<ScrollViewer Grid.Row="1"
+					  VerticalScrollBarVisibility="Auto"
+					  HorizontalScrollBarVisibility="Disabled">
+			<ItemsControl x:Name="InputSourcesList">
+				<ItemsControl.ItemTemplate>
+					<DataTemplate>
+						<Border Style="{StaticResource InputItemStyle}">
+							<Grid>
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="Auto"/>
+									<ColumnDefinition Width="*"/>
+									<ColumnDefinition Width="Auto"/>
+								</Grid.ColumnDefinitions>
+
+								<CheckBox Grid.Column="0"
+										  VerticalAlignment="Center"
+										  IsChecked="{Binding IsEnabled, Mode=TwoWay}"
+										  Margin="0,0,8,0"/>
+
+								<TextBox Grid.Column="1"
+										 Text="{Binding Label, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+										 VerticalAlignment="Center"
+										 Background="Transparent"
+										 Foreground="{DynamicResource App.Foreground}"
+										 BorderThickness="0,0,0,1"
+										 BorderBrush="{DynamicResource App.Foreground.Shadow}"
+										 Padding="4,2"/>
+
+								<TextBlock Grid.Column="2"
+										   Text="{Binding ValueHex}"
+										   VerticalAlignment="Center"
+										   Foreground="{DynamicResource App.Foreground.Shadow}"
+										   FontFamily="Consolas"
+										   FontSize="11"
+										   Margin="8,0,0,0"/>
+							</Grid>
+						</Border>
+					</DataTemplate>
+				</ItemsControl.ItemTemplate>
+			</ItemsControl>
+		</ScrollViewer>
+
+		<StackPanel Grid.Row="2"
+					Orientation="Horizontal"
+					HorizontalAlignment="Right"
+					Margin="0,12,0,0">
+			<Button x:Name="SaveButton"
+					Content="Save"
+					Width="80"
+					Padding="8,4"
+					Margin="0,0,8,0"
+					Click="SaveButton_Click"/>
+			<Button x:Name="CancelButton"
+					Content="Cancel"
+					Width="80"
+					Padding="8,4"
+					Click="CancelButton_Click"/>
+		</StackPanel>
+	</Grid>
+</Window>

--- a/Source/Monitorian.Core/Views/InputSourceConfigWindow.xaml.cs
+++ b/Source/Monitorian.Core/Views/InputSourceConfigWindow.xaml.cs
@@ -1,0 +1,102 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+
+using Monitorian.Core.Models;
+using Monitorian.Core.ViewModels;
+
+namespace Monitorian.Core.Views;
+
+public partial class InputSourceConfigWindow : Window
+{
+	private readonly MonitorViewModel _viewModel;
+	private readonly ObservableCollection<InputSourceConfigItem> _items;
+
+	public InputSourceConfigWindow(MonitorViewModel viewModel)
+	{
+		InitializeComponent();
+
+		_viewModel = viewModel;
+		_items = new ObservableCollection<InputSourceConfigItem>();
+
+		// Make sure we have the latest available inputs
+		_viewModel.UpdateInputSource();
+
+		// Populate the list with available input sources
+		var availableInputs = _viewModel.AvailableInputSources ?? System.Array.Empty<byte>();
+		var configuredInputs = _viewModel.InputSources ?? System.Array.Empty<InputSourceItem>();
+
+		foreach (var value in availableInputs)
+		{
+			var configured = configuredInputs.FirstOrDefault(x => x.Value == value);
+			var item = new InputSourceConfigItem
+			{
+				Value = value,
+				Label = configured?.Label ?? InputSourceItem.GetDefaultLabel(value),
+				IsEnabled = configured?.IsEnabled ?? true
+			};
+			_items.Add(item);
+		}
+
+		InputSourcesList.ItemsSource = _items;
+	}
+
+	private void SaveButton_Click(object sender, RoutedEventArgs e)
+	{
+		// Convert to InputSourceItem array and save
+		var inputSources = _items
+			.Select(x => new InputSourceItem(x.Value, x.Label, x.IsEnabled))
+			.ToArray();
+
+		_viewModel.InputSources = inputSources;
+		DialogResult = true;
+		Close();
+	}
+
+	private void CancelButton_Click(object sender, RoutedEventArgs e)
+	{
+		DialogResult = false;
+		Close();
+	}
+}
+
+/// <summary>
+/// Configuration item for the UI
+/// </summary>
+public class InputSourceConfigItem : INotifyPropertyChanged
+{
+	public byte Value { get; set; }
+
+	public string ValueHex => $"0x{Value:X2}";
+
+	private string _label;
+	public string Label
+	{
+		get => _label;
+		set
+		{
+			if (_label != value)
+			{
+				_label = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Label)));
+			}
+		}
+	}
+
+	private bool _isEnabled;
+	public bool IsEnabled
+	{
+		get => _isEnabled;
+		set
+		{
+			if (_isEnabled != value)
+			{
+				_isEnabled = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsEnabled)));
+			}
+		}
+	}
+
+	public event PropertyChangedEventHandler PropertyChanged;
+}

--- a/Source/Monitorian.Core/Views/MainWindow.xaml
+++ b/Source/Monitorian.Core/Views/MainWindow.xaml
@@ -574,6 +574,94 @@
 			<Setter Property="FillIconData" Value="M 0,0 L 0,10 5,10 5,0 Z M 10,0 L 10,10"/>
 		</Style>
 
+		<Style x:Key="InputSourceButtonStyle" TargetType="{x:Type controls:InputSourceButton}">
+			<Setter Property="Focusable" Value="False"/>
+			<Setter Property="Width" Value="28"/>
+			<Setter Property="Height" Value="30"/>
+			<Setter Property="Padding" Value="0"/>
+			<Setter Property="IsLastVisibleButton" Value="False"/>
+			<Setter Property="Foreground" Value="{StaticResource Icon.Foreground.Normal}"/>
+			<Setter Property="SnapsToDevicePixels" Value="True"/>
+			<Setter Property="UseLayoutRounding" Value="True"/>
+			<Setter Property="ToolTipService.InitialShowDelay" Value="1000"/>
+			<Setter Property="StrokeIconData" Value="M 1,2 L 1,8 5,8 5,2 Z M 6,4 L 10,4 M 6,6 L 10,6"/>
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="{x:Type controls:InputSourceButton}">
+						<Grid>
+							<Border x:Name="border"
+									Background="Transparent">
+								<Grid Margin="{TemplateBinding Padding}">
+									<Grid Height="{Binding RelativeSource={RelativeSource Self}, Path=ActualWidth}"
+										  Margin="7,6" VerticalAlignment="Center"
+										  RenderOptions.EdgeMode="Aliased">
+										<Path x:Name="StrokeIcon"
+											  Data="{TemplateBinding StrokeIconData}" Stretch="Uniform"
+											  Stroke="{TemplateBinding Foreground}" StrokeThickness="1"/>
+										<Path x:Name="FillIcon"
+											  Data="{TemplateBinding FillIconData}" Stretch="Uniform"
+											  Fill="{TemplateBinding Foreground}"/>
+									</Grid>
+								</Grid>
+							</Border>
+
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal"/>
+									<VisualState x:Name="MouseOver">
+										<Storyboard>
+											<ColorAnimation Storyboard.TargetName="border"
+															Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)"
+															Duration="0:0:0.1"
+															To="{DynamicResource Icon.Background.MouseOverColor}"/>
+											<ColorAnimation Storyboard.TargetName="StrokeIcon"
+															Storyboard.TargetProperty="(Shape.Stroke).(SolidColorBrush.Color)"
+															Duration="0:0:0.1"
+															To="{DynamicResource App.ForegroundColor}"/>
+											<ColorAnimation Storyboard.TargetName="FillIcon"
+															Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)"
+															Duration="0:0:0.1"
+															To="{DynamicResource App.ForegroundColor}"/>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Pressed">
+										<Storyboard>
+											<ColorAnimation Storyboard.TargetName="border"
+															Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)"
+															Duration="0"
+															To="{DynamicResource Icon.Background.PressedColor}"/>
+											<ColorAnimation Storyboard.TargetName="StrokeIcon"
+															Storyboard.TargetProperty="(Shape.Stroke).(SolidColorBrush.Color)"
+															Duration="0"
+															To="{DynamicResource App.ForegroundColor}"/>
+											<ColorAnimation Storyboard.TargetName="FillIcon"
+															Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)"
+															Duration="0"
+															To="{DynamicResource App.ForegroundColor}"/>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Disabled">
+										<Storyboard>
+											<DoubleAnimation Storyboard.TargetName="border"
+															 Storyboard.TargetProperty="Opacity"
+															 Duration="0"
+															 To="0"/>
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+			<Style.Triggers>
+				<Trigger Property="IsLastVisibleButton" Value="True">
+					<Setter Property="Width" Value="31"/>
+					<Setter Property="Padding" Value="0,0,3,0"/>
+				</Trigger>
+			</Style.Triggers>
+		</Style>
+
 		<!-- Number Label -->
 		<Style x:Key="NumberLabelStyle" TargetType="{x:Type Label}">
 			<Setter Property="VerticalAlignment" Value="Center"/>
@@ -651,6 +739,11 @@
 													 IsEnabled="{Binding IsContrastSupported, Mode=OneWay}"
 													 Visibility="{Binding Settings.EnablesContrast, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverterKey}}"
 													 IsChecked="{Binding IsContrastChanging, Mode=TwoWay}"/>
+
+								<!-- Input Source -->
+								<controls:InputSourceButton Style="{StaticResource InputSourceButtonStyle}"
+														   ToolTip="{x:Static properties:Resources.SwitchInputSource}"
+														   Visibility="{Binding Settings.EnablesInputSource, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverterKey}}"/>
 							</StackPanel>
 						</Grid>
 

--- a/Source/Monitorian.Core/Views/MenuWindow.xaml
+++ b/Source/Monitorian.Core/Views/MenuWindow.xaml
@@ -139,6 +139,13 @@
 						  IsChecked="{Binding Settings.EnablesContrast}"/>
 		</ContentControl>
 
+		<ContentControl Style="{StaticResource MenuItemStyle}">
+			<ToggleButton Padding="8,4"
+						  Style="{StaticResource CheckButtonItemStyle}"
+						  Content="{x:Static properties:Resources.EnableInputSource}"
+						  IsChecked="{Binding Settings.EnablesInputSource}"/>
+		</ContentControl>
+
 		<Separator Style="{StaticResource MenuSeparatorStyle}"/>
 
 		<!-- Close -->


### PR DESCRIPTION
> [!NOTE]  
> This PR was developed with AI assistance

## Summary

Adds a graphical user interface for switching monitor input sources directly from the Monitorian tray popup. This complements the existing command-line input switching functionality by providing a quick, visual way to change inputs.

- Adds an input source button next to each monitor's brightness slider
- Shows a popup with available input sources (auto-detected via VCP code 0x60)
- Allows users to configure custom labels for inputs (e.g., rename "HDMI 1" to "Work PC")
- Allows hiding unused inputs from the quick-switch menu
- Settings are persisted per-monitor

## How it works

1. Enable "Enable switching input source" in the right-click settings menu
2. Click the input source icon (monitor with signal lines) next to any monitor
3. Select an input from the dropdown to switch immediately
4. Use "Configure..." to customize input labels or hide unused inputs

## Closes

- Closes #449 (Adding the option to switch input signals)
- Closes #464 (Feature request: Adding support to send VCP code over command-line to the monitor) - UI complement
- Closes #686 (Input control)
- Closes #171 (Request - Add support for changing monitor input via DDC)

## Screenshots

1.
<img width="256" height="175" alt="image" src="https://github.com/user-attachments/assets/f4873ad7-a6ee-4d1d-8cd7-8cf69e101669" />

2.
<img width="495" height="184" alt="image" src="https://github.com/user-attachments/assets/dbaa32a6-f913-4715-8aed-a9d7eb945375" />

3.
<img width="432" height="186" alt="image" src="https://github.com/user-attachments/assets/66967201-c735-4fa0-8cb7-f3153fc65807" />

4.
<img width="379" height="418" alt="image" src="https://github.com/user-attachments/assets/ce737d65-994e-4aed-a35a-49de05d4d889" />

