### PR TITLE
fix: DDC monitor recovery after reboot

### DIFF
--- a/Source/Monitorian.Core/AppControllerCore.cs
+++ b/Source/Monitorian.Core/AppControllerCore.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -427,6 +427,13 @@ public class AppControllerCore
 				foreach (var m in Monitors.Where(x => !x.IsControllable))
 					m.IsTarget = !controllableMonitorExists;
 
+				// If any reachable monitor failed to report brightness (e.g. DDC/CI not yet initialized on a DisplayPort monitor after reboot),
+				// schedule additional rescans so the monitor can recover once the link is ready.
+				if (Monitors.Any(x => x.IsReachable && !x.IsControllable))
+				{
+					ScheduleDdcRecoveryScan();
+				}
+
 				OperationRecorder.AddGroupRecordItems(nameof(Monitors), Monitors.Select(x => x.ToString()));
 				await OperationRecorder.EndGroupRecordAsync();
 
@@ -441,6 +448,33 @@ public class AppControllerCore
 
 				Interlocked.Exchange(ref _scanCount, 0);
 			}
+		}
+	}
+
+	private int _ddcRecoveryScanCount;
+	private static readonly int[] _ddcRecoveryIntervals = [5, 5, 10, 10, 15, 15];
+
+	private async void ScheduleDdcRecoveryScan()
+	{
+		var count = Interlocked.Increment(ref _ddcRecoveryScanCount);
+		if (count > 1)
+			return; // Already scheduled
+
+		try
+		{
+			foreach (var interval in _ddcRecoveryIntervals)
+			{
+				await Task.Delay(TimeSpan.FromSeconds(interval));
+
+				if (!Monitors.Any(x => x.IsReachable && !x.IsControllable))
+					break; // All monitors recovered
+
+				await ScanAsync(TimeSpan.FromSeconds(1));
+			}
+		}
+		finally
+		{
+			Interlocked.Exchange(ref _ddcRecoveryScanCount, 0);
 		}
 	}
 

--- a/Source/Monitorian.Core/Models/Monitor/MonitorManager.cs
+++ b/Source/Monitorian.Core/Models/Monitor/MonitorManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -56,7 +56,7 @@ internal class MonitorManager
 		public byte DisplayIndex => _deviceItem.DisplayIndex;
 		public byte MonitorIndex => _deviceItem.MonitorIndex;
 		public ConnectionType Connection => _displayItem.Connection;
-		public bool IsInternal => _displayItem.IsInternal;		
+		public bool IsInternal => _displayItem.IsInternal;
 		public DisplayIdSet DisplayIdSet => _displayItem.DisplayIdSet;
 
 		public BasicItem(
@@ -219,16 +219,14 @@ internal class MonitorManager
 			{
 				foreach (var physicalItem in physicalItems)
 				{
-					int index = -1;
-					if (physicalItem.Capability.IsBrightnessSupported ||
-						_preclearedIds.Value.Any())
-					{
-						index = basicItems.FindIndex(x =>
-							!x.IsInternal &&
-							(x.DisplayIndex == handleItem.DisplayIndex) &&
-							(x.MonitorIndex == physicalItem.MonitorIndex) &&
-							string.Equals(x.Description, physicalItem.Description, StringComparison.OrdinalIgnoreCase));
-					}
+					// Try to match by DisplayIndex, MonitorIndex, and Description for external monitors regardless of whether brightness is reported as supported.
+					// After a reboot or reconnect, DDC/CI over DisplayPort may not be fully initialized yet and the capability query can transiently report brightness as unsupported.
+					int index = basicItems.FindIndex(x =>
+						!x.IsInternal &&
+						(x.DisplayIndex == handleItem.DisplayIndex) &&
+						(x.MonitorIndex == physicalItem.MonitorIndex) &&
+						string.Equals(x.Description, physicalItem.Description, StringComparison.OrdinalIgnoreCase));
+
 					if (index < 0)
 					{
 						physicalItem.Handle.Dispose();
@@ -246,21 +244,33 @@ internal class MonitorManager
 					{
 						capability = MonitorCapability.PreclearedCapability;
 					}
+
+					if (capability is not null)
+					{
+						yield return new DdcMonitorItem(
+							deviceInstanceId: basicItem.DeviceInstanceId,
+							description: basicItem.AlternativeDescription,
+							displayIndex: basicItem.DisplayIndex,
+							monitorIndex: basicItem.MonitorIndex,
+							monitorRect: handleItem.MonitorRect,
+							connection: basicItem.Connection,
+							handle: physicalItem.Handle,
+							capability: capability);
+					}
 					else
 					{
-						physicalItem.Handle.Dispose();
-						continue;
+						// The monitor was matched but DDC/CI brightness is not (yet) supported.
+						// Keep it as a DdcMonitorItem with the physical handle so that subsequent rescans can retry the capability query once the DDC/CI link is ready.
+						yield return new DdcMonitorItem(
+							deviceInstanceId: basicItem.DeviceInstanceId,
+							description: basicItem.AlternativeDescription,
+							displayIndex: basicItem.DisplayIndex,
+							monitorIndex: basicItem.MonitorIndex,
+							monitorRect: handleItem.MonitorRect,
+							connection: basicItem.Connection,
+							handle: physicalItem.Handle,
+							capability: physicalItem.Capability);
 					}
-
-					yield return new DdcMonitorItem(
-						deviceInstanceId: basicItem.DeviceInstanceId,
-						description: basicItem.AlternativeDescription,
-						displayIndex: basicItem.DisplayIndex,
-						monitorIndex: basicItem.MonitorIndex,
-						monitorRect: handleItem.MonitorRect,
-						connection: basicItem.Connection,
-						handle: physicalItem.Handle,
-						capability: capability);
 
 					basicItems.RemoveAt(index);
 					if (basicItems.Count == 0)
@@ -290,7 +300,7 @@ internal class MonitorManager
 						monitorIndex: basicItem.MonitorIndex,
 						monitorRect: handleItem.MonitorRect,
 						connection: basicItem.Connection,
-						isInternal: basicItem.IsInternal,						
+						isInternal: basicItem.IsInternal,
 						brightnessLevels: desktopItem.BrightnessLevels);
 
 					basicItems.RemoveAt(index);
@@ -451,8 +461,8 @@ internal class MonitorManager
 		[DataMember(Order = 0)]
 		public string System { get; private set; }
 
-		// When Name property of DataMemberAttribute contains a space or specific character 
-		// (e.g. !, ?), DataContractJsonSerializer.WriteObject method will internally throw 
+		// When Name property of DataMemberAttribute contains a space or specific character
+		// (e.g. !, ?), DataContractJsonSerializer.WriteObject method will internally throw
 		// a System.Xml.XmlException while it will work fine.
 		[DataMember(Order = 1, Name = "Device Context - DeviceItems")]
 		public DeviceContext.DeviceItem[] DeviceItems { get; private set; }

--- a/Source/Monitorian.Core/ViewModels/MainWindowViewModel.cs
+++ b/Source/Monitorian.Core/ViewModels/MainWindowViewModel.cs
@@ -64,7 +64,8 @@ public class MainWindowViewModel : ViewModelBase
 					{
 						var monitor = MonitorsView.Cast<MonitorViewModel>()
 							.FirstOrDefault(x => ReferenceEquals(x, _controller.SelectedMonitor));
-						monitor?.IsSelected = true;
+						if (monitor is not null)
+							monitor.IsSelected = true;
 					}
 				}
 				break;
@@ -112,6 +113,7 @@ public class MainWindowViewModel : ViewModelBase
 	internal void Deactivate()
 	{
 		var monitor = MonitorsView.Cast<MonitorViewModel>().FirstOrDefault(x => x.IsSelectedByKey);
-		monitor?.IsByKey = false;
+		if (monitor is not null)
+			monitor.IsByKey = false;
 	}
 }

--- a/Source/Monitorian.Core/Views/Controls/FocusTextBox.cs
+++ b/Source/Monitorian.Core/Views/Controls/FocusTextBox.cs
@@ -86,7 +86,8 @@ public class SwitchTextBox : FocusTextBox
 		this.Unloaded += OnUnloaded;
 
 		_window = Window.GetWindow(this);
-		_window?.Closed += OnClosed;
+		if (_window is not null)
+			_window.Closed += OnClosed;
 	}
 
 	private void OnUnloaded(object sender, RoutedEventArgs e)

--- a/Source/Monitorian.Core/Views/Controls/Sliders/EnhancedSlider.cs
+++ b/Source/Monitorian.Core/Views/Controls/Sliders/EnhancedSlider.cs
@@ -277,7 +277,8 @@ public class EnhancedSlider : Slider
 
 	protected virtual void CloseToolTip(Track track)
 	{
-		_autoToolTip?.IsOpen = false;
+		if (_autoToolTip is not null)
+			_autoToolTip.IsOpen = false;
 		track.Thumb.ToolTip = null;
 	}
 

--- a/Source/StartupAgency/StartupAgent.cs
+++ b/Source/StartupAgency/StartupAgent.cs
@@ -105,7 +105,11 @@ public class StartupAgent : IDisposable
 	public Func<string[], Task<string>> HandleRequestAsync
 	{
 		get => _holder?.HandleRequestAsync;
-		set => _holder?.HandleRequestAsync = value;
+		set
+		{
+			if (_holder is not null)
+				_holder.HandleRequestAsync = value;
+		}
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary
- keep matched external DDC monitors even when brightness capability is temporarily unavailable after reboot or reconnect
- add follow-up recovery scans when a reachable monitor is detected but not yet controllable
- improve recovery for DisplayPort monitors whose DDC/CI link becomes ready a few seconds after startup
## Why
Some external monitors, especially over DisplayPort, may report DDC/CI brightness support as unavailable immediately after system startup. In that window, Monitorian can detect the monitor but fail to control brightness until the user rescans manually.
This change keeps those monitors associated with their physical handles and retries scanning for a short period, so brightness control can recover automatically once the DDC/CI link is initialized.
## Notes
- no change to normal monitor detection flow when DDC/CI is already available
- recovery scans stop early once all reachable monitors become controllable