### PR TITLE
Fix: Add DDC/CI probe fallback for monitors with missing capabilities

### DIFF
--- a/Source/Monitorian.Core/Models/Monitor/MonitorConfiguration.cs
+++ b/Source/Monitorian.Core/Models/Monitor/MonitorConfiguration.cs
@@ -288,9 +288,19 @@ internal class MonitorConfiguration
 					capabilitiesData: (verbose && !vcpCodes.Any() ? GetCapabilitiesData(physicalMonitorHandle, capabilitiesStringLength) : null));
 			}
 		}
+		// Fallback: Probe brightness directly via DDC/CI when capabilities
+		// don't explicitly report support. Some monitors (e.g., certain Samsung 4K
+		// models) respond to brightness VCP commands but don't report MC_CAPS_BRIGHTNESS
+		// or include Luminance in their capabilities string in a parseable format.
+		bool isLowLevelProbed = false;
+		if (!isHighLevelSupported)
+		{
+			isLowLevelProbed = ProbeBrightness(physicalMonitorHandle);
+		}
+
 		return new MonitorCapability(
 			isHighLevelBrightnessSupported: isHighLevelSupported,
-			isLowLevelBrightnessSupported: false,
+			isLowLevelBrightnessSupported: isLowLevelProbed,
 			isContrastSupported: false);
 
 		static string MakeCapabilitiesReport(IReadOnlyDictionary<byte, byte[]> vcpCodeValues)
@@ -326,6 +336,47 @@ internal class MonitorConfiguration
 				Marshal.FreeHGlobal(dataPointer);
 			}
 		}
+	}
+
+	/// <summary>
+	/// Probes if brightness can be read via DDC/CI, even when capabilities don't report it.
+	/// Tries high-level GetMonitorBrightness first, then falls back to low-level VCP Luminance.
+	/// </summary>
+	/// <param name="physicalMonitorHandle">Physical monitor handle</param>
+	/// <returns>True if brightness can be read successfully</returns>
+	/// <remarks>
+	/// Some monitors (e.g., certain Samsung 4K models) respond to brightness VCP commands
+	/// but don't report MC_CAPS_BRIGHTNESS or include Luminance in their capabilities
+	/// string in a parseable format. This method probes actual DDC/CI communication
+	/// to determine real brightness support.
+	/// </remarks>
+	private static bool ProbeBrightness(SafePhysicalMonitorHandle physicalMonitorHandle)
+	{
+		if ((physicalMonitorHandle is null) || physicalMonitorHandle.IsClosed)
+			return false;
+
+		// Try high-level brightness function first
+		if (GetMonitorBrightness(
+			physicalMonitorHandle,
+			out uint _,
+			out uint _,
+			out uint _))
+		{
+			return true;
+		}
+
+		// Try low-level VCP code for Luminance
+		if (GetVCPFeatureAndVCPFeatureReply(
+			physicalMonitorHandle,
+			(byte)VcpCode.Luminance,
+			out _,
+			out uint _,
+			out uint _))
+		{
+			return true;
+		}
+
+		return false;
 	}
 
 	private static IEnumerable<byte> EnumerateVcpCodes(string source)

--- a/Source/Monitorian.Core/Models/Monitor/MonitorManager.cs
+++ b/Source/Monitorian.Core/Models/Monitor/MonitorManager.cs
@@ -228,6 +228,18 @@ internal class MonitorManager
 							(x.DisplayIndex == handleItem.DisplayIndex) &&
 							(x.MonitorIndex == physicalItem.MonitorIndex) &&
 							string.Equals(x.Description, physicalItem.Description, StringComparison.OrdinalIgnoreCase));
+
+						// Fallback: some monitors (e.g., Samsung 4K models connected via
+						// certain interfaces) may report different descriptions in
+						// EnumDisplayDevices vs GetPhysicalMonitorsFromHMONITOR.
+						// Try matching by display/monitor index only.
+						if (index < 0)
+						{
+							index = basicItems.FindIndex(x =>
+								!x.IsInternal &&
+								(x.DisplayIndex == handleItem.DisplayIndex) &&
+								(x.MonitorIndex == physicalItem.MonitorIndex));
+						}
 					}
 					if (index < 0)
 					{


### PR DESCRIPTION
## Problem

Monitors that respond to brightness DDC/CI commands but fail to report capabilities correctly (e.g., certain Samsung 4K UHD models) are classified as `UnreachableMonitorItem` and appear in the list without a brightness slider.

Two root causes were identified:

1. **`MonitorConfiguration.GetMonitorCapability()`** only considers a monitor as brightness-capable if `MC_CAPS_BRIGHTNESS` is reported or the capabilities string contains the `Luminance` VCP code in a parseable format. Some monitors don't meet either condition but still respond to brightness commands.

2. **`MonitorManager` DDC/CI matching** requires an exact string match between the monitor description from `EnumDisplayDevices` and `GetPhysicalMonitorsFromHMONITOR`. These descriptions can differ (e.g., "Samsung U28E590D" vs "SyncMaster U28E590D").

## Changes

### `MonitorConfiguration.cs`
- Added `ProbeBrightness()` method that directly tests DDC/CI communication by calling:
  - `GetMonitorBrightness` (high-level)
  - `GetVCPFeatureAndVCPFeatureReply` for `Luminance` (low-level VCP code 0x10)
- Used as fallback in `GetMonitorCapability()` when capabilities parsing doesn't report brightness support.

### `MonitorManager.cs`
- Added index-based fallback matching (`DisplayIndex` + `MonitorIndex`) when description matching fails, for cases where `EnumDisplayDevices` and `GetPhysicalMonitorsFromHMONITOR` report different names for the same monitor.

## Testing

- ✅ Tested with Samsung UHD 4K 28" — previously shown without brightness slider, now works correctly.
- ✅ All existing tests pass.
- ✅ No impact on monitors that already work correctly (probing only runs when capabilities are not reported).